### PR TITLE
Clarify usage of blocks in templates

### DIFF
--- a/tutorials/04-more-views.rst
+++ b/tutorials/04-more-views.rst
@@ -123,6 +123,10 @@ At the end of our ``content`` block in ``templates/blog/post_detail.html`` let's
         No comments yet.
     {% endfor %}
 
+.. HINT::
+
+    Remember that in a template that **extends** another template, all code needs to go in a named ``{% block %}`` section.  HTML outside of a ``{% block %}`` sction will not be used.
+
 .. IMPORTANT::
 
     We forgot to add a test for this!  Why don't you add a test to make sure comments appear on the blog post page.


### PR DESCRIPTION
This was a problem for someone that added the above HTML snippet after their `{% endblock content %}` and the page silently ignored their markup.

Is this the right place to add this note?
