### PR TITLE
Corrected tutorial link to point to current tutorial version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Tutorials
 ---------
 
 The latest version of the tutorials is available at
-http://learning-django-by-testing.rtfd.org
+http://test-driven-django-development.readthedocs.org
 
 
 Building


### PR DESCRIPTION
Trey, Looks like README.rst has an out of date link under tutorial category - Carol
