### PR TITLE
Update 07-templatetags.rst

### DIFF
--- a/tutorials/07-templatetags.rst
+++ b/tutorials/07-templatetags.rst
@@ -98,7 +98,7 @@ Then modify our second column to use our ``entry_history`` template tag:
         {% entry_history %}
     </div>
 
-Reload the homepage and make sure our dummy text appears.
+Restart the server and make sure our dummy text appears.
 
 
 Make it work


### PR DESCRIPTION
Line 101, we need to restart the server, not just reload the page, or Django will throw a TemplateSyntaxError saying that 'blog_tags' is not a valid tag library.
