### PR TITLE
Update super() method usage

### DIFF
--- a/myblog/blog/models.py
+++ b/myblog/blog/models.py
@@ -28,7 +28,7 @@ class Entry(models.Model):
 
     def save(self, *args, **kwargs):
         self.slug = slugify(self.title)
-        super().save(*args, **kwargs)
+        super(Entry, self).save(*args, **kwargs)
 
 class Comment(models.Model):
     entry = models.ForeignKey(Entry)


### PR DESCRIPTION
Python 2.7 doesn't support this syntax. super() should have arguments in Python 2