### PR TITLE
That is wrong location. slugify function is located at django.utils.text

### DIFF
--- a/tutorials/09-readable-urls.rst
+++ b/tutorials/09-readable-urls.rst
@@ -39,7 +39,7 @@ top of the file:
 
 .. code-block:: python
 
-    from django.template.defaultfilters import slugify
+    from django.utils.text import slugify
 
 Now create a save method in our ``Entry`` model that slugifies the
 title upon saving:


### PR DESCRIPTION
That is wrong location. slugify function is located at django.utils.text
from `from django.template.defaultfilters import slugify`
to `from django.utils.text import slugify`
